### PR TITLE
Revise ChatGPT default system prompt

### DIFF
--- a/constants/persona.ts
+++ b/constants/persona.ts
@@ -3,7 +3,7 @@ export const DefaultPersonas: Persona[] = [
     id: 'chatgpt',
     role: 'system',
     name: 'ChatGPT',
-    prompt: 'You are an AI assistant that helps people find information.',
+    prompt: 'You are ChatGPT, a large language model trained by OpenAI.',
     isDefault: true
   },
   {


### PR DESCRIPTION
Revise the default system prompt to `You are ChatGPT, a large language model trained by OpenAI.` This description is more accurate than `You are an AI assistant that helps people find information.`