### PR TITLE
allow to change model

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ For OpenAI account:
 | ------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------ |
 | OPENAI_API_BASE_URL | Use if you plan to use a reverse proxy for `api.openai.com`.                                            | `https://api.openai.com` |
 | OPENAI_API_KEY      | Secret key string obtained from the [OpenAI API website](https://platform.openai.com/account/api-keys). |
+| OPENAI_MODEL        | Model of GPT used                                                                                       | `gpt-3.5-turbo`          |
 
 For Azure OpenAI account:
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -54,7 +54,7 @@ const getApiConfig = () => {
     }
     apiUrl = `${apiBaseUrl}/v1/chat/completions`
     apiKey = process.env.OPENAI_API_KEY || ''
-    model = 'gpt-3.5-turbo' // todo: allow this to be passed through from client and support gpt-4
+    model = process.env.OPENAI_MODEL || 'gpt-3.5-turbo'
   }
 
   return { apiUrl, apiKey, model }


### PR DESCRIPTION
Add env variable to change the model. Tested on with `gpt-3.5-turbo-1106` since I don't have access to GPT4 API.

This was the fastest way to change it by the user, since most users are developers I think it's ok to use env variable, since you also don't have UI to change the API Key.